### PR TITLE
HCF-704 Remove hard-coded references to *.service.cf.internal and use properties

### DIFF
--- a/jobs/gorouter/spec
+++ b/jobs/gorouter/spec
@@ -120,12 +120,18 @@ properties:
 
   uaa.clients.gorouter.secret:
     description: "Password for UAA client for the gorouter."
+  uaa.token_endpoint:
+    decsription: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
   uaa.port:
     description: "Port on which UAA is running."
     default: 8080
   uaa.ssl.port:
     description: "Secure Port on which UAA is running."
 
+  routing-api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
   routing-api.port:
     description: "Port on which routing-api is running."
     default: 3000

--- a/jobs/gorouter/templates/gorouter.yml.erb
+++ b/jobs/gorouter/templates/gorouter.yml.erb
@@ -41,7 +41,7 @@ droplet_stale_threshold: 120
 publish_active_apps_interval: 0 # 0 means disabled
 
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   client_name: "gorouter"
   client_secret: <%= p("uaa.clients.gorouter.secret") %>
   port: <%= p("uaa.ssl.port") %>
@@ -49,7 +49,7 @@ oauth:
 
 <% if p("routing_api.enabled") %>
 routing_api:
-  uri: http://routing-api.service.cf.internal
+  uri: <%= p("routing-api.uri") %>
   port: <%= p("routing-api.port") %>
   auth_disabled: <%= p("routing-api.auth_disabled") %>
 <% end %>

--- a/jobs/router_configurer/spec
+++ b/jobs/router_configurer/spec
@@ -26,12 +26,24 @@ properties:
     description: "String representing interval for collecting statistic metrics from tcp proxy. Units: ms, s, m h"
     default: "1m"
 
+  routing_api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
+
+  routing_api.port:
+    description: "Port of routing api"
+    default: "3000"
+
   routing_api.auth_disabled:
     description: "auth disabled setting of routing api"
     default: false
 
   router_configurer.oauth_secret:
     description: "Password for UAA client for tcp "
+
+  uaa.token_endpoint:
+    decsription: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
 
   uaa.tls_port:
     description: "Secure Port on which UAA is running."

--- a/jobs/router_configurer/templates/router_configurer.yml.erb
+++ b/jobs/router_configurer/templates/router_configurer.yml.erb
@@ -1,13 +1,13 @@
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   client_name: "tcp_router"
   client_secret: <%= p("router_configurer.oauth_secret") %>
   port: <%= p("uaa.tls_port") %>
   skip_ssl_validation: <%= p("skip_ssl_validation") %>
 
 routing_api:
-  uri: http://routing-api.service.cf.internal
-  port: 3000
+  uri: <%= p("routing_api.uri") %>
+  port: <%= p("routing_api.port") %>
   auth_disabled: <%= p("routing_api.auth_disabled") %>
 
 

--- a/jobs/routing-api/spec
+++ b/jobs/routing-api/spec
@@ -54,6 +54,9 @@ properties:
     description: "Host to ping for confirmation of DNS resolution"
     default: consul.service.cf.internal
 
+  uaa.token_endpoint:
+    decsription: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
   uaa.tls_port:
     description: "Secure Port on which UAA is running."
 

--- a/jobs/routing-api/templates/routing-api.yml.erb
+++ b/jobs/routing-api/templates/routing-api.yml.erb
@@ -8,7 +8,7 @@ metron_config:
 metrics_reporting_interval: <%= p("routing_api.metrics_reporting_interval") %>
 statsd_endpoint: <%= p("routing_api.statsd_endpoint") %>
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   port: <%= p("uaa.tls_port") %>
   skip_ssl_validation: <%= p("skip_ssl_validation") %>
 debug_address: <%= p("routing_api.debug_address") %>

--- a/jobs/tcp_emitter/spec
+++ b/jobs/tcp_emitter/spec
@@ -28,7 +28,11 @@ properties:
   tcp_emitter.bbs.client_key:
     description: "PEM-encoded client key"
 
-  tcp_emitter.routing_api_port:
+  routing_api.uri:
+    description: "URL where the routing API can be reached internally"
+    default: http://routing-api.service.cf.internal
+
+  routing_api.port:
     description: "Port of routing api"
     default: "3000"
 
@@ -58,6 +62,10 @@ properties:
   skip_ssl_validation:
     description: Skip TLS verification when talking to UAA
     default: false
+
+  uaa.token_endpoint:
+    decsription: "UAA token endpoint host name"
+    default: uaa.service.cf.internal
 
   uaa.tls_port:
     description: "Secure Port on which UAA is running."

--- a/jobs/tcp_emitter/templates/tcp_emitter.yml.erb
+++ b/jobs/tcp_emitter/templates/tcp_emitter.yml.erb
@@ -1,13 +1,13 @@
 oauth:
-  token_endpoint: uaa.service.cf.internal
+  token_endpoint: <%= p("uaa.token_endpoint") %>
   client_name: "tcp_emitter"
   client_secret: <%= p("tcp_emitter.oauth_secret") %>
   port: <%= p("uaa.tls_port") %>
   skip_ssl_validation: <%= p("skip_ssl_validation") %>
 
 routing_api:
-  uri: http://routing-api.service.cf.internal
-  port: 3000
+  uri: <%= p("routing_api.uri") %>
+  port: <%= p("routing_api.port") %>
   auth_disabled: <%= p("routing_api.auth_disabled") %>
 
 


### PR DESCRIPTION
This makes it possible to run in configurations where a different service discovery mechanism is involved.  Also cleaned up a couple instances of hard-coded port numbers for routing-api (though it isn't yet possible to make it listen on a different port).

See also: cloudfoundry/cf-release!915 cloudfoundry-incubator/etcd-release!9 cloudfoundry-incubator/diego-release!153

(I'm not linking those PRs here so they don't get a link to this PR; I'll do so for the one to real upstream.)
